### PR TITLE
Fix bug in template matrix used to represent relative position

### DIFF
--- a/clie/inputters/vector.py
+++ b/clie/inputters/vector.py
@@ -133,8 +133,10 @@ def batchify(batch):
     if struct_relative_pos:
         struct_relpos_rep = torch.LongTensor(batch_size, max_len, max_len).fill_(max_seq_len)
         template_mat = torch.zeros((max_len, max_len))
-        template_mat[torch.triu_indices(max_len, max_len)] = 1
-        template_mat[torch.tril_indices(max_len, max_len)] = -1
+        [rows, cols] = torch.triu_indices(max_len, max_len)
+        template_mat[rows, cols] = 1
+        [rows, cols] = torch.tril_indices(max_len, max_len)
+        template_mat[rows, cols] = -1
         template_mat.fill_diagonal_(0)
 
     bert_embed_rep = None


### PR DESCRIPTION
I notice a bug in this section of codes:
```
        template_mat = torch.zeros((max_len, max_len))
        template_mat[torch.triu_indices(max_len, max_len)] = 1
        template_mat[torch.tril_indices(max_len, max_len)] = -1
        template_mat.fill_diagonal_(0)
```
For example, using `max_len=3`, `template_mat` will be equal to:
```
tensor([[ 0., -1., -1.],
        [-1.,  0., -1.],
        [-1., -1.,  0.]])
```
However, I believe the desired values are:
```
tensor([[ 0., 1., 1.],
        [-1.,  0., 1.],
        [-1., -1.,  0.]])
```
This pull request was made to fix this bug. However, please abandon this in case my understanding was wrong.